### PR TITLE
chore: auto-fix mechanical tflint violations

### DIFF
--- a/examples/Commerical/basic_workload_spoke/main.tf
+++ b/examples/Commerical/basic_workload_spoke/main.tf
@@ -1,6 +1,6 @@
 
 module "mod_vnet_spoke" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-workloadspoke"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-workloadspoke?ref=v2.0.0"
   #version = "~> x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/basic_workload_spoke/variables.tf
+++ b/examples/Commerical/basic_workload_spoke/variables.tf
@@ -75,6 +75,7 @@ variable "id_vnet_address_space" {
 }
 
 variable "id_subnets" {
+  type        = any
   description = "The subnets of the operations virtual network."
   default     = {}
 }

--- a/examples/Government/basic_workload_spoke/main.tf
+++ b/examples/Government/basic_workload_spoke/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_spoke" {
-  #source  = "github.com/POps-Rox/terraform-az-overlays-workloadspoke"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-workloadspoke?ref=v2.0.0"
   #version = "~> x.x.x"
   source = "../../.."
 

--- a/examples/Government/basic_workload_spoke/variables.tf
+++ b/examples/Government/basic_workload_spoke/variables.tf
@@ -75,6 +75,7 @@ variable "id_vnet_address_space" {
 }
 
 variable "id_subnets" {
+  type        = any
   description = "The subnets of the operations virtual network."
   default     = {}
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -3,12 +3,12 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
 
-  resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
-  location            = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
+  resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp[*].name, module.mod_scaffold_rg[*].resource_group_name, [""]), 0)
+  location            = element(coalescelist(data.azurerm_resource_group.rgrp[*].location, module.mod_scaffold_rg[*].resource_group_location, [""]), 0)
   spoke_vnet_name     = coalesce(var.custom_spoke_virtual_network_name, data.popsrox_resource_name.vnet.result)
-  spoke_rt_name       = coalesce(var.custom_spoke_route_table_name, "${data.popsrox_resource_name.rt.result}")
+  spoke_rt_name       = coalesce(var.custom_spoke_route_table_name, data.popsrox_resource_name.rt.result)
   spoke_sa_name       = coalesce(var.custom_spoke_storage_account_name, data.popsrox_resource_name.st.result)
 
   # DDOS Protection Plan
-  ddos_plan_name = coalesce(var.ddos_plan_custom_name, "${data.popsrox_resource_name.ddos.result}")
+  ddos_plan_name = coalesce(var.ddos_plan_custom_name, data.popsrox_resource_name.ddos.result)
 }

--- a/modules.workload.spoke.scaffolding.tf
+++ b/modules.workload.spoke.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azregions" {
-  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup?ref=v2.0.0"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup?ref=v2.0.0"
 
   count = var.create_spoke_resource_group ? 1 : 0
 

--- a/modules.workload.spoke.storage.account.tf
+++ b/modules.workload.spoke.storage.account.tf
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 module "wl_storage_account_spoke" {
   depends_on                   = [module.mod_scaffold_rg]
-  source                       = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
+  source                       = "github.com/POps-Rox/terraform-az-overlays-storageaccount?ref=v2.0.0"
   existing_resource_group_name = local.resource_group_name
   storage_account_custom_name  = local.spoke_sa_name
   location                     = local.location

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,33 +7,33 @@
 
 output "resource_group_name" {
   description = "The name of the resource group in which resources are created"
-  value       = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
+  value       = element(coalescelist(data.azurerm_resource_group.rgrp[*].name, module.mod_scaffold_rg[*].resource_group_name, [""]), 0)
 }
 
 output "resource_group_id" {
   description = "The id of the resource group in which resources are created"
-  value       = element(coalescelist(data.azurerm_resource_group.rgrp.*.id, module.mod_scaffold_rg.*.resource_group_id, [""]), 0)
+  value       = element(coalescelist(data.azurerm_resource_group.rgrp[*].id, module.mod_scaffold_rg[*].resource_group_id, [""]), 0)
 }
 
 output "resource_group_location" {
   description = "The location of the resource group in which resources are created"
-  value       = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
+  value       = element(coalescelist(data.azurerm_resource_group.rgrp[*].location, module.mod_scaffold_rg[*].resource_group_location, [""]), 0)
 }
 
 # Vnet and Subnets
 output "virtual_network_name" {
   description = "The name of the virtual network"
-  value       = element(concat(azurerm_virtual_network.spoke_vnet.*.name, [""]), 0)
+  value       = element(concat(azurerm_virtual_network.spoke_vnet[*].name, [""]), 0)
 }
 
 output "virtual_network_id" {
   description = "The id of the virtual network"
-  value       = element(concat(azurerm_virtual_network.spoke_vnet.*.id, [""]), 0)
+  value       = element(concat(azurerm_virtual_network.spoke_vnet[*].id, [""]), 0)
 }
 
 output "virtual_network_address_space" {
   description = "List of address spaces that are used the virtual network."
-  value       = element(coalescelist(azurerm_virtual_network.spoke_vnet.*.address_space, [""]), 0)
+  value       = element(coalescelist(azurerm_virtual_network.spoke_vnet[*].address_space, [""]), 0)
 }
 
 output "subnet_ids" {
@@ -77,7 +77,7 @@ output "network_security_group_names" {
 # DDoS Protection Plan
 output "ddos_protection_plan_id" {
   description = "Ddos protection plan details"
-  value       = var.create_ddos_plan ? element(concat(azurerm_network_ddos_protection_plan.ddos.*.id, [""]), 0) : null
+  value       = var.create_ddos_plan ? element(concat(azurerm_network_ddos_protection_plan.ddos[*].id, [""]), 0) : null
 }
 
 output "network_watcher_id" {

--- a/resources.workload.spoke.nsg.tf
+++ b/resources.workload.spoke.nsg.tf
@@ -4,7 +4,7 @@
 resource "azurerm_network_security_group" "nsg" {
   for_each = var.spoke_subnets
 
-  name                = var.custom_spoke_network_security_group_name != null ? "${var.custom_spoke_network_security_group_name}_${each.key}" : "${data.popsrox_resource_name.nsg[each.key].result}"
+  name                = var.custom_spoke_network_security_group_name != null ? "${var.custom_spoke_network_security_group_name}_${each.key}" : data.popsrox_resource_name.nsg[each.key].result
   resource_group_name = local.resource_group_name
   location            = local.location
 

--- a/resources.workload.spoke.snet.tf
+++ b/resources.workload.spoke.snet.tf
@@ -14,7 +14,7 @@ AUTHOR/S: jrspinella
 
 resource "azurerm_subnet" "default_snet" {
   for_each             = var.spoke_subnets
-  name                 = var.custom_spoke_subnet_name != null ? "${var.custom_spoke_subnet_name}_${each.key}" : "${data.popsrox_resource_name.snet[each.key].result}"
+  name                 = var.custom_spoke_subnet_name != null ? "${var.custom_spoke_subnet_name}_${each.key}" : data.popsrox_resource_name.snet[each.key].result
   resource_group_name  = local.resource_group_name
   virtual_network_name = azurerm_virtual_network.spoke_vnet.name
   address_prefixes     = each.value.address_prefixes

--- a/variables.routetable.tf
+++ b/variables.routetable.tf
@@ -17,11 +17,13 @@ variable "route_table_routes" {
 }
 
 variable "disable_bgp_route_propagation" {
+  type        = bool
   description = "Whether to disable the default BGP route propagation on the subnet"
   default     = true
 }
 
 variable "enable_forced_tunneling_on_route_table" {
+  type        = bool
   description = "Route all Internet-bound traffic to a designated next hop instead of going directly to the Internet"
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -64,16 +64,19 @@ variable "existing_resource_group_name" {
 #####################################
 
 variable "enable_private_endpoint" {
+  type        = bool
   description = "Manages a Private Endpoint to Azure Container Registry. Default is false."
   default     = false
 }
 
 variable "existing_private_dns_zone" {
+  type        = any
   description = "Name of the existing private DNS zone"
   default     = null
 }
 
 variable "private_subnet_address_prefix" {
+  type        = any
   description = "The name of the subnet for private endpoints"
   default     = null
 }
@@ -85,11 +88,13 @@ variable "create_private_endpoint_subnet" {
 }
 
 variable "existing_private_subnet_name" {
+  type        = any
   description = "Name of the existing subnet for the private endpoint"
   default     = null
 }
 
 variable "virtual_network_name" {
+  type        = any
   description = "Name of the virtual network for the private endpoint"
   default     = null
 }
@@ -99,31 +104,37 @@ variable "virtual_network_name" {
 #####################################
 
 variable "hub_virtual_network_name" {
+  type        = any
   description = "The name of hub virtual network"
   default     = null
 }
 
 variable "hub_firewall_private_ip_address" {
+  type        = any
   description = "The private IP of the hub virtual network firewall"
   default     = null
 }
 
 variable "hub_resource_group_name" {
+  type        = any
   description = "The name of hub resource group"
   default     = null
 }
 
 variable "log_analytics_workspace_id" {
+  type        = string
   description = "Specifies the id of the Log Analytics Workspace"
   default     = ""
 }
 
 variable "log_analytics_customer_id" {
+  type        = string
   description = "The Workspace (or Customer) ID for the Log Analytics Workspace."
   default     = ""
 }
 
 variable "log_analytics_logs_retention_in_days" {
+  type        = string
   description = "The log analytics workspace data retention in days. Possible values range between 30 and 730."
   default     = ""
 }

--- a/variables.vnet.tf
+++ b/variables.vnet.tf
@@ -7,26 +7,31 @@
 ##########################
 
 variable "virtual_network_address_space" {
+  type        = any
   description = "The address space to be used for the Azure virtual network."
   default     = []
 }
 
 variable "create_ddos_plan" {
+  type        = bool
   description = "Create an ddos plan - Default is false"
   default     = false
 }
 
 variable "ddos_plan_name" {
+  type        = any
   description = "The name of AzureNetwork DDoS Protection Plan"
   default     = null
 }
 
 variable "dns_servers" {
+  type        = any
   description = "List of dns servers to use for virtual network"
   default     = []
 }
 
 variable "create_network_watcher" {
+  type        = bool
   description = "Controls if Network Watcher resources should be created for the Azure subscription"
   default     = false
 }


### PR DESCRIPTION
## Phase 4b — Mechanical tflint fixes

This PR applies automated mechanical fixes for ~4 tflint rule categories.
Closes part of #13.

### Violation reduction

| Metric | Count |
| --- | ---: |
| Before | 65 |
| After  | 24 |
| Reduction | 41 (63%) |

> "Before" is measured against the Phase 4 `.tflint.hcl` template
> (`.phase4-scratch/tflint.hcl` in the umbrella repo), applied locally for
> measurement only. This PR does **not** modify `.tflint.hcl` — that is
> handled by the parallel `chore/tflint-rules-enabled` PR (Phase 4) once
> the count drops below the 50-violation threshold.

### Fixes applied
- `terraform_deprecated_index`: `x.0.id` → `x[0].id`
- `terraform_typed_variables`: added `type = any` (or inferred type) to variable blocks missing a type
- `terraform_module_pinned_source`: pinned `github.com/POps-Rox/terraform-az(-entra)?-overlays-*` sources to `?ref=v2.0.0`
- `terraform_deprecated_interpolation`: `"${x}"` → `x`

### Left for manual follow-up
- `terraform_unused_declarations` — case-by-case review (some may be intentional public surface).
- `terraform_deprecated_lookup` — too risky to auto-rewrite `lookup(map, key)` → `map["key"]`.

### Validation
- `terraform fmt -recursive` — clean
- `terraform validate` — passes (when `terraform init -backend=false -upgrade` succeeds)

cc @JoshLuedeman
