### PR TITLE
chore(tflint): clean up unused declarations (11 Cat A, 9 Cat B)

### DIFF
--- a/examples/Commerical/basic_workload_spoke/data.tf
+++ b/examples/Commerical/basic_workload_spoke/data.tf
@@ -3,11 +3,6 @@ data "azurerm_virtual_network" "hub-vnet" {
   resource_group_name = "anoa-eus-hub-core-dev-rg"
 }
 
-data "azurerm_storage_account" "hub-st" {
-  name                = "anoaeus8173b4d424devst"
-  resource_group_name = "anoa-eus-hub-core-dev-rg"
-}
-
 data "azurerm_firewall" "hub-fw" {
   name                = "anoa-eus-hub-core-dev-fw"
   resource_group_name = "anoa-eus-hub-core-dev-rg"

--- a/examples/Commerical/basic_workload_spoke/variables.tf
+++ b/examples/Commerical/basic_workload_spoke/variables.tf
@@ -26,18 +26,6 @@ variable "default_location" {
   default     = "eastus"
 }
 
-variable "default_tags" {
-  type        = map(string)
-  description = "If specified, will set the default tags for all resources deployed by this module where supported."
-  default     = {}
-}
-
-variable "disable_base_module_tags" {
-  type        = bool
-  description = "If set to true, will remove the base module tags applied to all resources deployed by the module which support tags."
-  default     = false
-}
-
 #################################
 # Resource Lock Configuration
 #################################
@@ -46,12 +34,6 @@ variable "enable_resource_locks" {
   type        = bool
   description = "If set to true, will enable resource locks for all resources deployed by this module where supported."
   default     = false
-}
-
-variable "lock_level" {
-  description = "The level of lock to apply to the resources. Valid values are CanNotDelete, ReadOnly, or NotSpecified."
-  type        = string
-  default     = "CanNotDelete"
 }
 
 ################################

--- a/examples/Government/basic_workload_spoke/data.tf
+++ b/examples/Government/basic_workload_spoke/data.tf
@@ -3,11 +3,6 @@ data "azurerm_virtual_network" "hub-vnet" {
   resource_group_name = "anoa-usgva-hub-core-dev-rg"
 }
 
-data "azurerm_storage_account" "hub-st" {
-  name                = "anoausgva8173b4d424devst"
-  resource_group_name = "anoa-usgva-hub-core-dev-rg"
-}
-
 data "azurerm_firewall" "hub-fw" {
   name                = "anoa-usgva-hub-core-dev-fw"
   resource_group_name = "anoa-usgva-hub-core-dev-rg"

--- a/examples/Government/basic_workload_spoke/variables.tf
+++ b/examples/Government/basic_workload_spoke/variables.tf
@@ -26,18 +26,6 @@ variable "default_location" {
   default     = "eastus"
 }
 
-variable "default_tags" {
-  type        = map(string)
-  description = "If specified, will set the default tags for all resources deployed by this module where supported."
-  default     = {}
-}
-
-variable "disable_base_module_tags" {
-  type        = bool
-  description = "If set to true, will remove the base module tags applied to all resources deployed by the module which support tags."
-  default     = false
-}
-
 #################################
 # Resource Lock Configuration
 #################################
@@ -46,12 +34,6 @@ variable "enable_resource_locks" {
   type        = bool
   description = "If set to true, will enable resource locks for all resources deployed by this module where supported."
   default     = false
-}
-
-variable "lock_level" {
-  description = "The level of lock to apply to the resources. Valid values are CanNotDelete, ReadOnly, or NotSpecified."
-  type        = string
-  default     = "CanNotDelete"
 }
 
 ################################

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,7 +8,4 @@ locals {
   spoke_vnet_name     = coalesce(var.custom_spoke_virtual_network_name, data.popsrox_resource_name.vnet.result)
   spoke_rt_name       = coalesce(var.custom_spoke_route_table_name, data.popsrox_resource_name.rt.result)
   spoke_sa_name       = coalesce(var.custom_spoke_storage_account_name, data.popsrox_resource_name.st.result)
-
-  # DDOS Protection Plan
-  ddos_plan_name = coalesce(var.ddos_plan_custom_name, data.popsrox_resource_name.ddos.result)
 }

--- a/locals.tf
+++ b/locals.tf
@@ -9,8 +9,6 @@
 # The following block of locals are used to avoid using
 # empty object types in the code
 locals {
-  empty_list   = []
-  empty_map    = tomap({})
   empty_string = ""
 }
 

--- a/naming.tf
+++ b/naming.tf
@@ -53,13 +53,3 @@ data "popsrox_resource_name" "st" {
   suffixes      = compact([var.name_prefix == "" ? null : local.name_prefix, var.deploy_environment, local.name_suffix, var.use_naming ? "" : "st"])
   use_slug      = var.use_naming
 }
-
-data "popsrox_resource_name" "ddos" {
-  name          = var.workload_name
-  resource_type = "azurerm_network_ddos_protection_plan"
-  prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
-  suffixes      = compact([var.name_prefix == "" ? null : local.name_prefix, var.deploy_environment, local.name_suffix, var.use_naming ? "" : "ddospp"])
-  use_slug      = var.use_naming
-  clean_input   = true
-  separator     = "-"
-}

--- a/variables.naming.tf
+++ b/variables.naming.tf
@@ -59,6 +59,7 @@ variable "custom_spoke_route_table_name" {
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "ddos_plan_custom_name" {
   description = "The name of the custom ddos protection plan to create. If not set, the name will be generated using the 'name_prefix' and 'name_suffix' variables. If set, the 'name_prefix' variable will be ignored."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -63,36 +63,42 @@ variable "existing_resource_group_name" {
 # Private Endpoint Configuration   ##
 #####################################
 
+# tflint-ignore: terraform_unused_declarations
 variable "enable_private_endpoint" {
   type        = bool
   description = "Manages a Private Endpoint to Azure Container Registry. Default is false."
   default     = false
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "existing_private_dns_zone" {
   type        = any
   description = "Name of the existing private DNS zone"
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "private_subnet_address_prefix" {
   type        = any
   description = "The name of the subnet for private endpoints"
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "create_private_endpoint_subnet" {
   description = "Controls if the subnet should be created. If set to false, the subnet name must be provided. Default is false."
   type        = bool
   default     = false
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "existing_private_subnet_name" {
   type        = any
   description = "Name of the existing subnet for the private endpoint"
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "virtual_network_name" {
   type        = any
   description = "Name of the virtual network for the private endpoint"
@@ -133,6 +139,7 @@ variable "log_analytics_customer_id" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "log_analytics_logs_retention_in_days" {
   type        = string
   description = "The log analytics workspace data retention in days. Possible values range between 30 and 730."

--- a/variables.vnet.tf
+++ b/variables.vnet.tf
@@ -30,6 +30,7 @@ variable "dns_servers" {
   default     = []
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "create_network_watcher" {
   type        = bool
   description = "Controls if Network Watcher resources should be created for the Azure subscription"


### PR DESCRIPTION
## Summary
Resolves all 19 `terraform_unused_declarations` tflint warnings across the module root and both `basic_workload_spoke` examples.

## Classification

### Cat A — Truly dead (removed, 11)

**Root:**
| Item | Reason |
|---|---|
| `local.empty_list`, `local.empty_map` | Cruft in `locals.tf` — file already carries a "remove file if not needed" comment. `local.empty_string` is still used and kept. |
| `local.ddos_plan_name` | Orphaned. The resource uses `var.ddos_plan_name` directly; this dynamic-naming local was left behind after a refactor. |
| `data.popsrox_resource_name.ddos` | Only referenced from the dead local above. |

**Examples (`examples/Commerical/basic_workload_spoke` and `examples/Government/basic_workload_spoke`):**
| Item | Reason |
|---|---|
| `var.default_tags` | Declared in the example but the example's `module "mod_workload_spoke"` invocation never passes it through. Demo-code rot. |
| `var.disable_base_module_tags` | Same as above. |
| `var.lock_level` | Same as above. |
| `data.azurerm_storage_account.hub-st` | Declared but never referenced. |

### Cat B — Public API surface (annotated, 9)
| Variable | File | Reason |
|---|---|---|
| `enable_private_endpoint` | `variables.tf` | Private Endpoint feature group — documented public API |
| `existing_private_dns_zone` | `variables.tf` | Private Endpoint feature group |
| `private_subnet_address_prefix` | `variables.tf` | Private Endpoint feature group |
| `create_private_endpoint_subnet` | `variables.tf` | Private Endpoint feature group |
| `existing_private_subnet_name` | `variables.tf` | Private Endpoint feature group |
| `virtual_network_name` | `variables.tf` | Private Endpoint feature group |
| `log_analytics_logs_retention_in_days` | `variables.tf` | Documented public API |
| `create_network_watcher` | `variables.vnet.tf` | Documented public API |
| `ddos_plan_custom_name` | `variables.naming.tf` | Becomes orphaned after the dead local removal above; preserved as documented public API surface (custom override pattern). |

### Cat C
None.

## Counts
- Cat A: 11
- Cat B: 9
- Cat C: 0

## Verification
```
$ tflint --enable-rule=terraform_unused_declarations           # root
$ (cd examples/Commerical/basic_workload_spoke && tflint ...)
$ (cd examples/Government/basic_workload_spoke && tflint ...)
0 unused_declarations warnings remaining in all three locations
```

Refs #13